### PR TITLE
Refactored direct call bindings to be more explicitly named

### DIFF
--- a/Assets/dotnow/Scripts/Integration/Unity/DirectCallBindings.Component.cs
+++ b/Assets/dotnow/Scripts/Integration/Unity/DirectCallBindings.Component.cs
@@ -1,0 +1,17 @@
+﻿using System.Threading.Tasks;
+using dotnow;
+using dotnow.Runtime;
+
+namespace UnityEngine
+{
+    internal static partial class DirectCallBindings
+    {
+        [Preserve]
+        [CLRMethodDirectCallBinding(typeof(Component), "get_transform")]
+        public static void unityEngine_Component_GetTransform(StackData[] stack, int offset)
+        {
+            stack[offset].refValue = ((Component)stack[offset].refValue.Unwrap()).transform;
+            stack[offset].type = StackData.ObjectType.Ref;
+        }
+    }
+}

--- a/Assets/dotnow/Scripts/Integration/Unity/DirectCallBindings.GameObject.cs
+++ b/Assets/dotnow/Scripts/Integration/Unity/DirectCallBindings.GameObject.cs
@@ -1,0 +1,16 @@
+﻿using dotnow;
+using dotnow.Runtime;
+
+namespace UnityEngine
+{
+    internal static partial class DirectCallBindings
+    {
+        [Preserve]
+        [CLRMethodDirectCallBinding(typeof(GameObject), "get_transform")]
+        public static void unityEngine_GameObject_GetTransform(StackData[] stack, int offset)
+        {
+            stack[offset].refValue = ((GameObject)stack[offset].refValue).transform;
+            stack[offset].type = StackData.ObjectType.Ref;
+        }
+    }
+}

--- a/Assets/dotnow/Scripts/Integration/Unity/DirectCallBindings.Input.cs
+++ b/Assets/dotnow/Scripts/Integration/Unity/DirectCallBindings.Input.cs
@@ -1,0 +1,16 @@
+﻿using dotnow;
+using dotnow.Runtime;
+
+namespace UnityEngine
+{
+    internal static partial class DirectCallBindings
+    {
+        [Preserve]
+        [CLRMethodDirectCallBinding(typeof(Input), "GetKey", typeof(KeyCode))]
+        public static void UnityEngine_Input_GetKey(StackData[] stack, int offset)
+        {
+            stack[offset].value.Int32 = Input.GetKey((KeyCode)stack[offset].value.Int32) ? 1 : 0;
+            stack[offset].type = StackData.ObjectType.Int32;
+        }
+    }
+}

--- a/Assets/dotnow/Scripts/Integration/Unity/DirectCallBindings.Time.cs
+++ b/Assets/dotnow/Scripts/Integration/Unity/DirectCallBindings.Time.cs
@@ -1,0 +1,16 @@
+﻿using dotnow;
+using dotnow.Runtime;
+
+namespace UnityEngine
+{
+    internal static partial class DirectCallBindings
+    {
+        [Preserve]
+        [CLRMethodDirectCallBinding(typeof(Time), "get_time")]
+        public static void UnityEngine_Time_GetTime(StackData[] stack, int offset)
+        {
+            stack[offset].value.Single = Time.time;
+            stack[offset].type = StackData.ObjectType.Single;
+        }
+    }
+}

--- a/Assets/dotnow/Scripts/Integration/Unity/DirectCallBindings.Transform.cs
+++ b/Assets/dotnow/Scripts/Integration/Unity/DirectCallBindings.Transform.cs
@@ -8,40 +8,8 @@ using dotnow.Runtime;
 namespace UnityEngine
 {
 
-    internal static class DirectCallBindings
+    internal static partial class DirectCallBindings
     {
-        [Preserve]
-        [CLRMethodDirectCallBinding(typeof(Time), "get_time")]
-        public static void UnityEngine_Time_GetTime(StackData[] stack, int offset)
-        {
-            stack[offset].value.Single = Time.time;
-            stack[offset].type = StackData.ObjectType.Single;
-        }
-
-        [Preserve]
-        [CLRMethodDirectCallBinding(typeof(Input), "GetKey", typeof(KeyCode))]
-        public static void UnityEngine_Input_GetKey(StackData[] stack, int offset)
-        {
-            stack[offset].value.Int32 = Input.GetKey((KeyCode)stack[offset].value.Int32) ? 1 : 0;
-            stack[offset].type = StackData.ObjectType.Int32;
-        }
-
-        [Preserve]
-        [CLRMethodDirectCallBinding(typeof(GameObject), "get_transform")]
-        public static void unityEngine_GameObject_GetTransform(StackData[] stack, int offset)
-        {
-            stack[offset].refValue = ((GameObject)stack[offset].refValue).transform;
-            stack[offset].type = StackData.ObjectType.Ref;
-        }
-
-        [Preserve]
-        [CLRMethodDirectCallBinding(typeof(Component), "get_transform")]
-        public static void unityEngine_Component_GetTransform(StackData[] stack, int offset)
-        {
-            stack[offset].refValue = ((Component)stack[offset].refValue.Unwrap()).transform;
-            stack[offset].type = StackData.ObjectType.Ref;
-        }
-
         [Preserve]
         [CLRMethodDirectCallBinding(typeof(Transform), "Rotate", typeof(float), typeof(float), typeof(float))]
         public static void UnityEngine_Transform_Rotate_SingleSingleSingle(StackData[] stack, int offset)

--- a/Assets/dotnow/Scripts/Integration/Unity/DirectCallBindings.Vector2.cs
+++ b/Assets/dotnow/Scripts/Integration/Unity/DirectCallBindings.Vector2.cs
@@ -1,0 +1,15 @@
+﻿using dotnow;
+using dotnow.Runtime;
+
+namespace UnityEngine
+{
+    internal static partial class DirectCallBindings
+    {
+        [Preserve]
+        [CLRMethodDirectCallBinding(typeof(Vector2), "op_Subtraction", typeof(Vector2), typeof(Vector2))]
+        public static void unityEngine_Vector2_Subtraction(StackData[] stack, int offset)
+        {
+            stack[offset].refValue = (Vector2)stack[offset].refValue - (Vector2)stack[offset + 1].refValue;
+        }
+    }
+}


### PR DESCRIPTION
Switched DirectCallBindings.Transform to be a partial class. This allows us to create more partial classes with specific Unity component names to make the code more readable