### PR TITLE
Fix find generic method bug.

### DIFF
--- a/Assets/dotnow/Scripts/Core/AppDomain.cs
+++ b/Assets/dotnow/Scripts/Core/AppDomain.cs
@@ -808,7 +808,7 @@ namespace dotnow
                     MethodInfo[] methods = resolvedDeclaringType.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
 
                     // Find all closely matching methods
-                    IEnumerable<MethodInfo> potentialMethods = methods.Where(m => m.Name == reference.Name && m.IsGenericMethod == true && m.GetParameters().Length == reference.Parameters.Count);
+                    IEnumerable<MethodInfo> potentialMethods = methods.Where(m => m.Name == reference.Name && m.IsGenericMethod == true && m.GetParameters().Length == reference.Parameters.Count && m.GetGenericArguments().Length == genericArguments.Length);
 
                     try
                     {


### PR DESCRIPTION
Fix find generic method cause `ArgumentException: Incorrect length` and `AmbiguousMatchException: Ambiguous match found.` exception.